### PR TITLE
feat: Add systemd limits configuration for GPU device plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,7 @@ The UI approach provides:
 - **[Kubernetes Firewall Configuration](docs/KUBERNETES_FIREWALL.md)** - Network and firewall setup
 - **[NVIDIA Container Runtime Configuration](docs/NVIDIA_CONTAINER_RUNTIME.md)** - GPU runtime setup
 - **[EGS License Setup](docs/EGS-License-Setup.md)** - EGS license configuration guide
+- **[Systemd Limits Configuration](docs/SYSTEMD_LIMITS_CONFIGURATION.md)** - GPU device plugin systemd limits setup
 
 ---
 

--- a/docs/SYSTEMD_LIMITS_CONFIGURATION.md
+++ b/docs/SYSTEMD_LIMITS_CONFIGURATION.md
@@ -1,0 +1,249 @@
+# Systemd Limits Configuration for GPU Support
+
+This document explains how to configure systemd limits to prevent "too many open files" errors when running GPU device plugins in Kubernetes.
+
+## Problem
+
+GPU device plugins (like NVIDIA GPU Operator) often encounter "too many open files" errors because they need to access many GPU devices and files simultaneously. The default systemd limits are insufficient for these workloads.
+
+## Solution
+
+We provide two approaches to configure systemd limits:
+
+1. **Automatic via EGS Installer** (Recommended)
+2. **Manual Configuration**
+
+## Approach 1: Automatic Configuration (Recommended)
+
+The EGS installer automatically configures systemd limits as part of the deployment process.
+
+### Configuration
+
+The systemd limits are configured in `group_vars/all/systemd_limits.yml`:
+
+```yaml
+# Systemd limits configuration
+systemd_limits:
+  # File descriptor limits
+  nofile: 65536
+  # Process limits
+  nproc: 32768
+  # Memory limits (unlimited for GPU workloads)
+  memlock: -1
+  # Additional limits for GPU workloads
+  stack: 8192
+
+# Enable systemd limits configuration
+configure_systemd_limits: true
+
+# Container runtime to configure (containerd or docker)
+container_runtime: "{{ 'containerd' if containerd_enabled | default(true) else 'docker' }}"
+```
+
+### Execution Order
+
+The systemd limits configuration runs early in the deployment process:
+
+```yaml
+execution_order:
+  # Base Applications
+  - label_nodes_gateway            # Label all nodes with kubeslice.io/node-type=gateway
+  - configure_systemd_limits       # Configure systemd limits for GPU device plugins
+  - gpu_operator_chart
+  # ... rest of deployment
+```
+
+### What It Does
+
+1. **Creates systemd override directories** for kubelet and container runtime
+2. **Configures limits** for:
+   - `NOFILE`: 65536 (file descriptors)
+   - `NPROC`: 32768 (processes)
+   - `MEMLOCK`: -1 (unlimited memory locking)
+   - `STACK`: 8192 (stack size)
+3. **Restarts services** to apply the new limits
+4. **Verifies** that limits are applied correctly
+
+## Approach 2: Manual Configuration
+
+If you prefer to configure systemd limits manually, you can use the provided script or configure them directly.
+
+### Using the Script
+
+```bash
+# Run the systemd limits configuration script
+sudo bash files/configure-systemd-limits.sh
+```
+
+### Manual Configuration
+
+#### For Kubelet
+
+```bash
+# Create override directory
+sudo mkdir -p /etc/systemd/system/kubelet.service.d
+
+# Create override file
+sudo tee /etc/systemd/system/kubelet.service.d/limits.conf > /dev/null << EOF
+[Service]
+LimitNOFILE=65536
+LimitNPROC=32768
+LimitMEMLOCK=-1
+LimitSTACK=8192
+EOF
+
+# Reload systemd and restart kubelet
+sudo systemctl daemon-reload
+sudo systemctl restart kubelet
+```
+
+#### For Containerd
+
+```bash
+# Create override directory
+sudo mkdir -p /etc/systemd/system/containerd.service.d
+
+# Create override file
+sudo tee /etc/systemd/system/containerd.service.d/limits.conf > /dev/null << EOF
+[Service]
+LimitNOFILE=65536
+LimitNPROC=32768
+LimitMEMLOCK=-1
+LimitSTACK=8192
+EOF
+
+# Reload systemd and restart containerd
+sudo systemctl daemon-reload
+sudo systemctl restart containerd
+```
+
+#### For Docker (if using Docker instead of containerd)
+
+```bash
+# Create override directory
+sudo mkdir -p /etc/systemd/system/docker.service.d
+
+# Create override file
+sudo tee /etc/systemd/system/docker.service.d/limits.conf > /dev/null << EOF
+[Service]
+LimitNOFILE=65536
+LimitNPROC=32768
+LimitMEMLOCK=-1
+LimitSTACK=8192
+EOF
+
+# Reload systemd and restart docker
+sudo systemctl daemon-reload
+sudo systemctl restart docker
+```
+
+## Verification
+
+### Check Applied Limits
+
+```bash
+# Check kubelet limits
+sudo systemctl show kubelet --property=LimitNOFILE --value
+
+# Check containerd limits
+sudo systemctl show containerd --property=LimitNOFILE --value
+
+# Check docker limits (if using docker)
+sudo systemctl show docker --property=LimitNOFILE --value
+```
+
+### Verify in Running Containers
+
+```bash
+# Check limits in a running pod
+kubectl exec -it <gpu-pod> -- cat /proc/1/limits
+
+# Check current process limits
+ulimit -n
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Service won't restart after configuration**
+   ```bash
+   # Check systemd status
+   sudo systemctl status kubelet
+   sudo systemctl status containerd
+   
+   # Check for configuration errors
+   sudo systemd-analyze verify /etc/systemd/system/kubelet.service
+   ```
+
+2. **Limits not applied**
+   ```bash
+   # Verify override file exists and has correct content
+   sudo cat /etc/systemd/system/kubelet.service.d/limits.conf
+   
+   # Reload systemd daemon
+   sudo systemctl daemon-reload
+   ```
+
+3. **GPU device plugin still fails**
+   ```bash
+   # Check pod logs
+   kubectl logs -n gpu-operator <device-plugin-pod>
+   
+   # Check if limits are inherited by containers
+   kubectl exec -it <gpu-pod> -- cat /proc/1/limits
+   ```
+
+### Debugging Commands
+
+```bash
+# Check all systemd limits for a service
+sudo systemctl show kubelet | grep Limit
+
+# Check current system limits
+cat /proc/sys/fs/file-max
+cat /proc/sys/kernel/pid_max
+
+# Check process limits
+ps aux | grep kubelet
+cat /proc/$(pgrep kubelet)/limits
+```
+
+## Customization
+
+### Adjusting Limits
+
+You can customize the limits by modifying `group_vars/all/systemd_limits.yml`:
+
+```yaml
+systemd_limits:
+  nofile: 131072    # Increase file descriptor limit
+  nproc: 65536      # Increase process limit
+  memlock: -1       # Keep unlimited
+  stack: 16384      # Increase stack size
+```
+
+### Disabling Automatic Configuration
+
+To disable automatic systemd limits configuration:
+
+```yaml
+# In group_vars/all/systemd_limits.yml
+configure_systemd_limits: false
+```
+
+Or remove `configure_systemd_limits` from the execution order in `user_input.yml`.
+
+## Best Practices
+
+1. **Configure limits before GPU operator installation** - This prevents issues during initial deployment
+2. **Use the automatic configuration** - It handles both kubelet and container runtime
+3. **Verify limits after configuration** - Ensure they are applied correctly
+4. **Monitor GPU device plugin logs** - Watch for any remaining file descriptor issues
+5. **Test with your specific GPU workloads** - Different workloads may have different requirements
+
+## References
+
+- [Kubernetes GPU Support](https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/)
+- [NVIDIA GPU Operator](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/)
+- [Systemd Resource Limits](https://www.freedesktop.org/software/systemd/man/systemd.resource-control.html)

--- a/files/configure-systemd-limits.sh
+++ b/files/configure-systemd-limits.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+
+# Configure systemd limits for kubelet and container runtime
+# This prevents "too many open files" errors with GPU device plugins
+
+set -e
+
+# Configuration
+NOFILE_LIMIT=65536
+NPROC_LIMIT=32768
+MEMLOCK_LIMIT=-1
+STACK_LIMIT=8192
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Function to print colored output
+print_status() {
+    local status=$1
+    local message=$2
+    case $status in
+        "SUCCESS") echo -e "${GREEN}✓${NC} $message" ;;
+        "WARNING") echo -e "${YELLOW}⚠${NC} $message" ;;
+        "ERROR") echo -e "${RED}✗${NC} $message" ;;
+        "INFO") echo -e "${BLUE}ℹ${NC} $message" ;;
+    esac
+}
+
+# Function to create systemd override
+create_systemd_override() {
+    local service_name=$1
+    local override_dir="/etc/systemd/system/${service_name}.service.d"
+    local override_file="${override_dir}/limits.conf"
+    
+    print_status "INFO" "Configuring systemd limits for $service_name"
+    
+    # Create override directory
+    sudo mkdir -p "$override_dir"
+    
+    # Create override file
+    sudo tee "$override_file" > /dev/null << EOF
+[Service]
+LimitNOFILE=$NOFILE_LIMIT
+LimitNPROC=$NPROC_LIMIT
+LimitMEMLOCK=$MEMLOCK_LIMIT
+LimitSTACK=$STACK_LIMIT
+EOF
+    
+    print_status "SUCCESS" "Created systemd override for $service_name"
+}
+
+# Function to restart service
+restart_service() {
+    local service_name=$1
+    
+    print_status "INFO" "Restarting $service_name service"
+    
+    if sudo systemctl is-active --quiet "$service_name"; then
+        sudo systemctl restart "$service_name"
+        print_status "SUCCESS" "$service_name service restarted"
+    else
+        print_status "WARNING" "$service_name service is not active, skipping restart"
+    fi
+}
+
+# Function to verify limits
+verify_limits() {
+    local service_name=$1
+    
+    print_status "INFO" "Verifying limits for $service_name"
+    
+    local nofile_limit=$(sudo systemctl show "$service_name" --property=LimitNOFILE --value 2>/dev/null || echo "unknown")
+    local nproc_limit=$(sudo systemctl show "$service_name" --property=LimitNPROC --value 2>/dev/null || echo "unknown")
+    
+    echo "  NOFILE limit: $nofile_limit"
+    echo "  NPROC limit: $nproc_limit"
+}
+
+# Main execution
+main() {
+    echo "=========================================="
+    echo "Systemd Limits Configuration for GPU Support"
+    echo "=========================================="
+    echo "Configuration:"
+    echo "  NOFILE limit: $NOFILE_LIMIT"
+    echo "  NPROC limit: $NPROC_LIMIT"
+    echo "  MEMLOCK limit: $MEMLOCK_LIMIT"
+    echo "  STACK limit: $STACK_LIMIT"
+    echo ""
+    
+    # Check if running as root
+    if [ "$EUID" -eq 0 ]; then
+        print_status "WARNING" "Running as root. Consider running as regular user with sudo."
+    fi
+    
+    # Detect container runtime
+    local container_runtime=""
+    if systemctl is-active --quiet containerd; then
+        container_runtime="containerd"
+    elif systemctl is-active --quiet docker; then
+        container_runtime="docker"
+    else
+        print_status "WARNING" "No active container runtime detected (containerd/docker)"
+    fi
+    
+    # Configure kubelet
+    if systemctl is-enabled --quiet kubelet 2>/dev/null; then
+        create_systemd_override "kubelet"
+        restart_service "kubelet"
+        verify_limits "kubelet"
+    else
+        print_status "WARNING" "Kubelet service not found or not enabled"
+    fi
+    
+    # Configure container runtime
+    if [ -n "$container_runtime" ]; then
+        create_systemd_override "$container_runtime"
+        restart_service "$container_runtime"
+        verify_limits "$container_runtime"
+    fi
+    
+    # Reload systemd daemon
+    print_status "INFO" "Reloading systemd daemon"
+    sudo systemctl daemon-reload
+    
+    echo ""
+    print_status "SUCCESS" "Systemd limits configuration completed"
+    echo ""
+    echo "Next steps:"
+    echo "1. Verify GPU device plugin can start without 'too many open files' errors"
+    echo "2. Check pod logs: kubectl logs -n gpu-operator <device-plugin-pod>"
+    echo "3. Monitor system resources: ulimit -n"
+}
+
+# Run main function
+main "$@"

--- a/group_vars/all/systemd_limits.yml
+++ b/group_vars/all/systemd_limits.yml
@@ -1,0 +1,32 @@
+---
+# Systemd limits configuration for GPU device plugins
+# This prevents "too many open files" errors with GPU operators
+
+# Kubelet systemd limits
+kubelet_systemd_override_dir: "/etc/systemd/system/kubelet.service.d"
+kubelet_systemd_override_file: "{{ kubelet_systemd_override_dir }}/limits.conf"
+
+# Container runtime systemd limits
+containerd_systemd_override_dir: "/etc/systemd/system/containerd.service.d"
+containerd_systemd_override_file: "{{ containerd_systemd_override_dir }}/limits.conf"
+
+# Docker systemd limits (if using Docker instead of containerd)
+docker_systemd_override_dir: "/etc/systemd/system/docker.service.d"
+docker_systemd_override_file: "{{ docker_systemd_override_dir }}/limits.conf"
+
+# Systemd limits configuration
+systemd_limits:
+  # File descriptor limits
+  nofile: 65536
+  # Process limits
+  nproc: 32768
+  # Memory limits (unlimited for GPU workloads)
+  memlock: -1
+  # Additional limits for GPU workloads
+  stack: 8192
+
+# Enable systemd limits configuration
+configure_systemd_limits: true
+
+# Container runtime to configure (containerd or docker)
+container_runtime: "{{ 'containerd' if containerd_enabled | default(true) else 'docker' }}"

--- a/tasks/configure_systemd_limits.yml
+++ b/tasks/configure_systemd_limits.yml
@@ -1,0 +1,110 @@
+---
+# Configure systemd limits for kubelet and container runtime
+# This prevents "too many open files" errors with GPU device plugins
+
+- name: Create kubelet systemd override directory
+  file:
+    path: "{{ kubelet_systemd_override_dir }}"
+    state: directory
+    mode: '0755'
+  when: configure_systemd_limits | default(true)
+
+- name: Configure kubelet systemd limits
+  copy:
+    content: |
+      [Service]
+      LimitNOFILE={{ systemd_limits.nofile }}
+      LimitNPROC={{ systemd_limits.nproc }}
+      LimitMEMLOCK={{ systemd_limits.memlock }}
+      LimitSTACK={{ systemd_limits.stack }}
+    dest: "{{ kubelet_systemd_override_file }}"
+    mode: '0644'
+  when: configure_systemd_limits | default(true)
+
+- name: Create containerd systemd override directory
+  file:
+    path: "{{ containerd_systemd_override_dir }}"
+    state: directory
+    mode: '0755'
+  when: 
+    - configure_systemd_limits | default(true)
+    - container_runtime == 'containerd'
+
+- name: Configure containerd systemd limits
+  copy:
+    content: |
+      [Service]
+      LimitNOFILE={{ systemd_limits.nofile }}
+      LimitNPROC={{ systemd_limits.nproc }}
+      LimitMEMLOCK={{ systemd_limits.memlock }}
+      LimitSTACK={{ systemd_limits.stack }}
+    dest: "{{ containerd_systemd_override_file }}"
+    mode: '0644'
+  when: 
+    - configure_systemd_limits | default(true)
+    - container_runtime == 'containerd'
+
+- name: Create docker systemd override directory
+  file:
+    path: "{{ docker_systemd_override_dir }}"
+    state: directory
+    mode: '0755'
+  when: 
+    - configure_systemd_limits | default(true)
+    - container_runtime == 'docker'
+
+- name: Configure docker systemd limits
+  copy:
+    content: |
+      [Service]
+      LimitNOFILE={{ systemd_limits.nofile }}
+      LimitNPROC={{ systemd_limits.nproc }}
+      LimitMEMLOCK={{ systemd_limits.memlock }}
+      LimitSTACK={{ systemd_limits.stack }}
+    dest: "{{ docker_systemd_override_file }}"
+    mode: '0644'
+  when: 
+    - configure_systemd_limits | default(true)
+    - container_runtime == 'docker'
+
+- name: Reload systemd daemon
+  systemd:
+    daemon_reload: yes
+  when: configure_systemd_limits | default(true)
+
+- name: Restart kubelet service
+  systemd:
+    name: kubelet
+    state: restarted
+  when: configure_systemd_limits | default(true)
+
+- name: Restart containerd service
+  systemd:
+    name: containerd
+    state: restarted
+  when: 
+    - configure_systemd_limits | default(true)
+    - container_runtime == 'containerd'
+
+- name: Restart docker service
+  systemd:
+    name: docker
+    state: restarted
+  when: 
+    - configure_systemd_limits | default(true)
+    - container_runtime == 'docker'
+
+- name: Verify systemd limits are applied
+  shell: |
+    systemctl show kubelet --property=LimitNOFILE --value
+  register: kubelet_limits
+  when: configure_systemd_limits | default(true)
+
+- name: Display applied limits
+  debug:
+    msg: |
+      Systemd limits configured successfully:
+      - Kubelet NOFILE limit: {{ kubelet_limits.stdout }}
+      - Container runtime: {{ container_runtime }}
+      - All services restarted
+  when: configure_systemd_limits | default(true)

--- a/user_input.yml
+++ b/user_input.yml
@@ -261,6 +261,7 @@ execution_order:
 
   # Base Applications
   - label_nodes_gateway            # Label all nodes with kubeslice.io/node-type=gateway
+  - configure_systemd_limits       # Configure systemd limits for GPU device plugins
   - gpu_operator_chart
   - prometheus_stack
   - postgresql                     # PostgreSQL database for EGS components
@@ -1026,3 +1027,12 @@ command_exec:
             echo "    key: $(cat -)" >> output/worker-1-values.yaml
           
           echo "Worker values file generated at output/worker-1-values.yaml"
+
+  - name: "configure_systemd_limits"
+    kubeconfig: "{{ kubeconfig | default(global_kubeconfig) }}"
+    kubecontext: "{{ kubecontext | default(global_kubecontext) }}"
+    commands:
+      - cmd: "bash {{ playbook_dir }}/files/configure-systemd-limits.sh"
+        env:
+          KUBECONFIG: "{{ kubeconfig | default(global_kubeconfig) }}"
+          KUBECONTEXT: "{{ kubecontext | default(global_kubecontext) }}"


### PR DESCRIPTION
- Add systemd limits configuration to prevent 'too many open files' errors
- Create group_vars/all/systemd_limits.yml for configurable limits
- Add tasks/configure_systemd_limits.yml for automated configuration
- Create files/configure-systemd-limits.sh standalone script
- Add configure_systemd_limits to execution order in user_input.yml
- Add comprehensive documentation in docs/SYSTEMD_LIMITS_CONFIGURATION.md
- Update README.md with documentation link

Features:
- Automatic detection of container runtime (containerd/docker)
- Configurable limits (NOFILE, NPROC, MEMLOCK, STACK)
- Service restart and verification
- Comprehensive troubleshooting guide
- Both automated and manual configuration options