### PR TITLE
Add control plane component tolerations support

### DIFF
--- a/templates/kubespray_group_vars_all.yml.j2
+++ b/templates/kubespray_group_vars_all.yml.j2
@@ -19,6 +19,24 @@ container_manager: {{ kubernetes_deployment.container_runtime | default('contain
 containerd_use_systemd_cgroup: true
 kubelet_cgroup_driver: systemd
 
+## Control Plane Tolerations
+# Add custom tolerations to control plane components via kubeadm patches
+{% if kubernetes_deployment.control_plane.get('tolerations', []) | length > 0 %}
+kubeadm_patches:
+{% for component in ['kube-apiserver', 'kube-controller-manager', 'kube-scheduler', 'etcd'] %}
+  - target: {{ component }}
+    type: strategic
+    patch:
+      spec:
+        tolerations:
+{% for toleration in kubernetes_deployment.control_plane.tolerations %}
+          - key: {{ toleration.key }}
+            value: {{ toleration.value }}
+            effect: {{ toleration.effect }}
+{% endfor %}
+{% endfor %}
+{% endif %}
+
 ## Network Configuration
 kube_network_plugin: {{ kubernetes_deployment.network_plugin | default('calico') }}
 kube_service_addresses: {{ kubernetes_deployment.network_config.service_subnet | default('10.233.0.0/18') }}

--- a/user_input.yml
+++ b/user_input.yml
@@ -26,6 +26,20 @@ kubernetes_deployment:
     secure: true                 # Whether to use HTTPS for API server connections
                                 # Should always be true in production environments
 
+  # Control Plane Component Configuration
+  # Configure tolerations and other settings for control plane components
+  control_plane:
+    # Tolerations for control plane components (API server, controller manager, scheduler, etcd)
+    # These allow control plane pods to be scheduled on tainted nodes
+    tolerations:
+      - key: "kubeslice.io/egs"           # Taint key to tolerate
+        value: "dedicated-node"           # Taint value to match
+        effect: "NoSchedule"              # Taint effect (NoSchedule, PreferNoSchedule, or NoExecute)
+    # Add more tolerations as needed:
+    # - key: "another-taint"
+    #   value: "some-value"
+    #   effect: "NoSchedule"
+
   # SSH Access Configuration
   # Required for Kubespray to access and configure nodes
   ssh_key_path: "/absolute/path/to/.ssh/k8s_rsa"  # Full path to the SSH private key file


### PR DESCRIPTION
- Added kubeadm_patches configuration in kubespray_group_vars_all.yml.j2
- Tolerations can be configured for all control plane components:
  * kube-apiserver
  * kube-controller-manager
  * kube-scheduler
  * etcd
- Added control_plane.tolerations section in user_input.yml
- Default toleration: kubeslice.io/egs=dedicated-node:NoSchedule
- Allows control plane pods to run on tainted nodes
- Supports multiple tolerations via YAML list configuration