### PR TITLE
Add CoreDNS tolerations support

### DIFF
--- a/templates/kubespray_group_vars_all.yml.j2
+++ b/templates/kubespray_group_vars_all.yml.j2
@@ -19,7 +19,7 @@ container_manager: {{ kubernetes_deployment.container_runtime | default('contain
 containerd_use_systemd_cgroup: true
 kubelet_cgroup_driver: systemd
 
-## Control Plane Tolerations
+## Control Plane and System Component Tolerations
 # Add custom tolerations to control plane components via kubeadm patches
 {% if kubernetes_deployment.control_plane.get('tolerations', []) | length > 0 %}
 kubeadm_patches:
@@ -34,6 +34,14 @@ kubeadm_patches:
             value: {{ toleration.value }}
             effect: {{ toleration.effect }}
 {% endfor %}
+{% endfor %}
+
+# Add tolerations to CoreDNS (and other DNS components)
+dns_extra_tolerations:
+{% for toleration in kubernetes_deployment.control_plane.tolerations %}
+  - key: {{ toleration.key }}
+    value: {{ toleration.value }}
+    effect: {{ toleration.effect }}
 {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
- Extended control plane toleration support to include CoreDNS
- CoreDNS will now use dns_extra_tolerations from control_plane.tolerations config
- All system components now support the custom toleration:
  * Control plane: kube-apiserver, kube-controller-manager, kube-scheduler, etcd (via kubeadm_patches)
  * DNS: CoreDNS (via dns_extra_tolerations)
  * Network: Calico, nodelocaldns (already have operator: Exists)
  * Proxy: kube-proxy (deployed via kubeadm on all nodes)
- This ensures all critical cluster components can run on tainted nodes